### PR TITLE
refactor: axios から fetch に移行する

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@book000/node-utils": "1.24.123",
     "@types/jest": "30.0.0",
     "@types/node": "24.12.2",
-    "axios": "1.15.0",
+
     "cheerio": "1.2.0",
     "eslint": "10.2.0",
     "eslint-config-standard": "17.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
-      axios:
-        specifier: 1.15.0
-        version: 1.15.0
       cheerio:
         specifier: 1.2.0
         version: 1.2.0
@@ -948,9 +945,6 @@ packages:
 
   axios@1.14.0:
     resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
-
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   babel-jest@30.3.0:
     resolution: {integrity: sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==}
@@ -3909,14 +3903,6 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   axios@1.14.0:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.5
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,4 @@
 import { load } from 'cheerio'
-import axios from 'axios'
 import { Notified } from './notified'
 import { Discord, Logger } from '@book000/node-utils'
 import { PexConfiguration } from './config'
@@ -16,8 +15,9 @@ interface Item {
 }
 
 async function getList(url: string) {
-  const response = await axios.get(url)
-  const html = response.data
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`fetch failed: ${res.status} ${res.statusText}`)
+  const html = await res.text()
   const $ = load(html)
 
   // ul.anken-list > a


### PR DESCRIPTION
fix book000/book000#102

axiosへの依存を削除し、ネイティブ fetch API に移行しました。

## 変更内容
- `axios` 依存を削除
- `fetch` API を使用するように変更
- 非2xxレスポンスに対するエラーハンドリングを追加