### PR TITLE
fix: TypeScript v6 非推奨設定の削除と型定義の追加

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,11 +22,10 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "ignoreDeprecations": "6.0",
-    "baseUrl": ".",
     "newLine": "LF",
+    "types": ["node", "jest"],
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## 概要

TypeScript 7.0 への移行に備え、tsconfig.json の非推奨設定を削除し、必要な型定義を追加します。

Fixes #1927

## 変更内容

- `baseUrl: "."` を削除（`moduleResolution: "bundler"` では不要）
- `paths` の値を `"src/*"` から `"./src/*"` に変更（相対パス形式に統一）
- `ignoreDeprecations: "6.0"` を削除（TypeScript 7.0 では機能しなくなるため）
- `types: ["node", "jest"]` を追加（TypeScript 6.0 で `@types/node`・`@types/jest` の自動読み込みが廃止されたため）

## 確認事項

- `pnpm exec tsc --noEmit` が正常終了することを確認
- `pnpm lint` が通ることを確認