### PR TITLE
fix(lint): eslint-plugin-unicorn の新規ルール指摘を解消

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ interface Config {
   }
 }
 
-export class PexConfiguration extends ConfigFramework<Config> {
+export class PexConfig extends ConfigFramework<Config> {
   protected validates(): Record<string, (config: Config) => boolean> {
     return {
       'discord is required': (config) => !!config.discord,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { load } from 'cheerio'
 import { Notified } from './notified'
 import { Discord, Logger } from '@book000/node-utils'
-import { PexConfiguration } from './config'
+import { PexConfig } from './config'
 
 const ItemStatus = {
   s1: '受付中',
@@ -15,9 +15,10 @@ interface Item {
 }
 
 async function getList(url: string) {
-  const res = await fetch(url)
-  if (!res.ok) throw new Error(`fetch failed: ${res.status} ${res.statusText}`)
-  const html = await res.text()
+  const response = await fetch(url)
+  if (!response.ok)
+    throw new Error(`fetch failed: ${response.status} ${response.statusText}`)
+  const html = await response.text()
   const $ = load(html)
 
   // ul.anken-list > a
@@ -56,7 +57,7 @@ async function main() {
   const logger = Logger.configure('main')
   logger.info('✨ main()')
 
-  const config = new PexConfiguration('./data/config.json')
+  const config = new PexConfig('./data/config.json')
   config.load()
   if (!config.validate()) {
     logger.error('❌ Config is invalid')

--- a/src/notified.ts
+++ b/src/notified.ts
@@ -13,7 +13,7 @@ export class Notified {
   }
 
   public isExists(key: string): boolean {
-    return key in this.notified
+    return Object.hasOwn(this.notified, key)
   }
 
   public isNotified(key: string, value: string): boolean {


### PR DESCRIPTION
## 概要

Renovate PR #1952 (`@book000/eslint-config` 1.15.4 -> 1.15.44) で CI が失敗している原因を修正する。

## 原因

`@book000/eslint-config` の更新に伴い `eslint-plugin-unicorn` が新しくなり、以下の既存コードが新規ルールに抵触する。

- `unicorn/name-replacements`: `PexConfiguration` -> `PexConfig`、`res` -> `response`
- `unicorn/no-computed-property-existence-check`: `key in this.notified` -> `Object.hasOwn(this.notified, key)`

## 対応

上記 4 件を機械的に修正した。挙動の変更はない。`@book000/eslint-config` 自体のバージョンはこの PR では変更していない (Renovate 側の #1952 に委ねる)。

## 確認

- `@book000/eslint-config@1.15.4`(現行) / `1.15.44`(#1952 の対象) の両方で `pnpm run lint`(prettier + eslint + tsc) が clean であることを確認済み
- `pnpm test` (テストなし、no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)