### PR TITLE
fix: Discord レート制限による unhandledRejection と重複通知を修正

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,17 +2,7 @@ import { load } from 'cheerio'
 import { Notified } from './notified'
 import { Discord, Logger } from '@book000/node-utils'
 import { PexConfiguration } from './config'
-
-const ItemStatus = {
-  s1: '受付中',
-  s2: '受付終了',
-} as const
-
-interface Item {
-  status: string
-  title: string
-  path: string
-}
+import { Item, ItemStatus, notifyItems } from './notify'
 
 async function getList(url: string) {
   const res = await fetch(url)
@@ -98,42 +88,7 @@ async function main() {
 
   // 新しく出てきたとき、ステータスに変化があったときに通知する
   const items = [...investmentList, ...timeDepositList]
-  for (const item of items) {
-    if (notified.isNotified(item.path, item.status)) {
-      continue
-    }
-    const isNew = !notified.isExists(item.path)
-
-    const log = isNew ? `New item` : `Status changed`
-    logger.info(`${log}: ${item.title} (${item.status})`)
-
-    const title = isNew
-      ? `:new:${item.title}`
-      : `:arrows_counterclockwise:${item.title}`
-    const previousStatus = notified.getNotified(item.path)
-    const description = isNew
-      ? `New item: \`${item.status}\``
-      : `Status changed: \`${previousStatus}\` -> \`${item.status}\``
-
-    if (!isFirst) {
-      await discord.sendMessage({
-        embeds: [
-          {
-            title,
-            description,
-            url: `https://pex.jp${item.path}`,
-            color: item.status === ItemStatus.s1 ? 0x00_ff_00 : 0xff_00_00,
-            timestamp: new Date().toISOString(),
-          },
-        ],
-      })
-    }
-
-    notified.setNotified(item.path, item.status)
-  }
-
-  notified.save()
-  logger.info('📝 Save notified')
+  await notifyItems(items, discord, notified, logger, isFirst)
 
   logger.info('🎉 Done')
 }

--- a/src/notify.test.ts
+++ b/src/notify.test.ts
@@ -1,0 +1,135 @@
+import { Discord, Logger } from '@book000/node-utils'
+import { Notified } from './notified'
+import { Item, notifyItems } from './notify'
+
+jest.mock('./notified')
+
+describe('notifyItems', () => {
+  const items: Item[] = [
+    { status: '受付中', title: 'item1', path: '/item1' },
+    { status: '受付中', title: 'item2', path: '/item2' },
+    { status: '受付中', title: 'item3', path: '/item3' },
+  ]
+
+  function createNotifiedMock(): jest.Mocked<Notified> {
+    return {
+      isExists: jest.fn().mockReturnValue(false),
+      isNotified: jest.fn().mockReturnValue(false),
+      getNotified: jest.fn().mockReturnValue(undefined),
+      setNotified: jest.fn(),
+      isFirst: jest.fn().mockReturnValue(false),
+      load: jest.fn(),
+      save: jest.fn(),
+    } as unknown as jest.Mocked<Notified>
+  }
+
+  function createLoggerMock(): jest.Mocked<Logger> {
+    return {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    } as unknown as jest.Mocked<Logger>
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('saves the notified state immediately after each item is processed', async () => {
+    const notified = createNotifiedMock()
+    const logger = createLoggerMock()
+    const discord = {
+      sendMessage: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<Discord>
+
+    const promise = notifyItems(items, discord, notified, logger, false)
+    await jest.runAllTimersAsync()
+    await promise
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock method reference
+    expect(notified.save).toHaveBeenCalledTimes(items.length)
+    expect(notified.setNotified.mock.invocationCallOrder[0]).toBeLessThan(
+      notified.save.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('continues processing remaining items when sendMessage rejects, without marking the failed item as notified', async () => {
+    const notified = createNotifiedMock()
+    const logger = createLoggerMock()
+    const discord = {
+      sendMessage: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('429: rate limited'))
+        .mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<Discord>
+
+    const promise = notifyItems(items, discord, notified, logger, false)
+    await jest.runAllTimersAsync()
+    await expect(promise).resolves.toBeUndefined()
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock method reference
+    expect(discord.sendMessage).toHaveBeenCalledTimes(items.length)
+    // 送信に失敗した item1 は次回実行時に再送されるよう、通知済みとして記録されない
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock method reference
+    expect(notified.setNotified).toHaveBeenCalledTimes(items.length - 1)
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock method reference
+    expect(notified.setNotified).not.toHaveBeenCalledWith(
+      items[0].path,
+      items[0].status
+    )
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock method reference
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('item1'),
+      expect.any(Error)
+    )
+  })
+
+  it('waits between consecutive sendMessage calls', async () => {
+    const notified = createNotifiedMock()
+    const logger = createLoggerMock()
+    const discord = {
+      sendMessage: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<Discord>
+
+    const promise = notifyItems(items, discord, notified, logger, false)
+
+    // 1件目の送信は待機なしで行われる
+    await Promise.resolve()
+    await Promise.resolve()
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock method reference
+    expect(discord.sendMessage).toHaveBeenCalledTimes(1)
+
+    // 2件目以降は送信間隔だけ待機してから送信される
+    await jest.advanceTimersByTimeAsync(999)
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock method reference
+    expect(discord.sendMessage).toHaveBeenCalledTimes(1)
+    await jest.advanceTimersByTimeAsync(1)
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock method reference
+    expect(discord.sendMessage).toHaveBeenCalledTimes(2)
+
+    await jest.runAllTimersAsync()
+    await promise
+  })
+
+  it('does not send messages on the first run, but still records the state', async () => {
+    const notified = createNotifiedMock()
+    const logger = createLoggerMock()
+    const discord = {
+      sendMessage: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<Discord>
+
+    await notifyItems(items, discord, notified, logger, true)
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock method reference
+    expect(discord.sendMessage).not.toHaveBeenCalled()
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock method reference
+    expect(notified.setNotified).toHaveBeenCalledTimes(items.length)
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock method reference
+    expect(notified.save).toHaveBeenCalledTimes(items.length)
+  })
+})

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -1,0 +1,95 @@
+import { Notified } from './notified'
+import { Discord, Logger } from '@book000/node-utils'
+
+export const ItemStatus = {
+  s1: '受付中',
+  s2: '受付終了',
+} as const
+
+export interface Item {
+  status: string
+  title: string
+  path: string
+}
+
+/**
+ * Discord API のレート制限を避けるための送信間隔(ミリ秒)
+ */
+export const DISCORD_SEND_INTERVAL_MS = 1000
+
+/**
+ * 指定したミリ秒だけ待機する。
+ * @param ms - 待機時間(ミリ秒)
+ */
+export async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * 未通知の案件を Discord に通知し、送信に成功するたびに通知結果を保存する。
+ * 送信に失敗した案件は通知済みとして記録せず、次回実行時に再送を試みる。
+ * @param items - 通知対象の候補となる案件一覧
+ * @param discord - 送信に使用する Discord クライアント
+ * @param notified - 通知済み状態の永続化を管理するインスタンス
+ * @param logger - ログ出力に使用するロガー
+ * @param isFirst - 初回実行かどうか(true の場合、通知は送信せず状態のみ記録する)
+ */
+export async function notifyItems(
+  items: Item[],
+  discord: Discord,
+  notified: Notified,
+  logger: Logger,
+  isFirst: boolean
+): Promise<void> {
+  let hasSentMessage = false
+  for (const item of items) {
+    if (notified.isNotified(item.path, item.status)) {
+      continue
+    }
+    const isNew = !notified.isExists(item.path)
+
+    const log = isNew ? `New item` : `Status changed`
+    logger.info(`${log}: ${item.title} (${item.status})`)
+
+    const title = isNew
+      ? `:new:${item.title}`
+      : `:arrows_counterclockwise:${item.title}`
+    const previousStatus = notified.getNotified(item.path)
+    const description = isNew
+      ? `New item: \`${item.status}\``
+      : `Status changed: \`${previousStatus}\` -> \`${item.status}\``
+
+    if (!isFirst) {
+      // Discord API のレート制限 (429) を避けるため、連続送信の間隔を空ける
+      if (hasSentMessage) {
+        await sleep(DISCORD_SEND_INTERVAL_MS)
+      }
+      hasSentMessage = true
+
+      try {
+        await discord.sendMessage({
+          embeds: [
+            {
+              title,
+              description,
+              url: `https://pex.jp${item.path}`,
+              color: item.status === ItemStatus.s1 ? 0x00_ff_00 : 0xff_00_00,
+              timestamp: new Date().toISOString(),
+            },
+          ],
+        })
+      } catch (error) {
+        // 送信に失敗した場合は通知未済のままにし、次回実行時に再送を試みる
+        logger.error(
+          `❌ Failed to send Discord message: ${item.title}`,
+          error as Error
+        )
+        continue
+      }
+    }
+
+    // クラッシュ時の重複通知を防ぐため、1件処理するごとに即時保存する
+    notified.setNotified(item.path, item.status)
+    notified.save()
+  }
+}


### PR DESCRIPTION
## 概要

新着通知処理中に Discord API のレート制限 (429) で `unhandledRejection` が発生し、プロセスがクラッシュすることで5分おきに重複通知が繰り返される問題を修正します。

## 変更内容

- `discord.sendMessage()` の連続呼び出しの間に 1 秒のスリープを挟み、レート制限の発生を抑える。
- `sendMessage()` を try/catch し、送信に失敗しても後続の通知・保存処理を止めないようにする。
- 送信に成功した案件は `setNotified()` 直後に `save()` を呼び、途中でクラッシュしても既に送信済みの分は再送されないようにする。
- 送信に失敗した案件は通知済みとして記録せず、次回実行時に再送を試みる。
- 通知ループを `notifyItems()` として `src/notify.ts` に切り出し、ユニットテストを追加。

## 動作確認

- `pnpm lint`(prettier / eslint / tsc)がすべて成功することを確認。
- `pnpm test` で追加したユニットテスト(4件)がすべて成功することを確認。

Closes #2055