### PR TITLE
chore: .worktreeinclude を追加してデータファイルをworktreeに含める

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+data/config.json
+data/notified.json


### PR DESCRIPTION
## 概要

`.worktreeinclude` を新規作成し、以下のパターンを追加しました。

- `data/config.json`
- `data/notified.json`

## 根拠

- `.gitignore` に `data/` が含まれている
- README.md: 「`data/config.json` を作成し、Discord の通知設定を行います。」
- `src/main.ts` で `new PexConfiguration('./data/config.json')` および `process.env.NOTIFIED_PATH ?? 'data/notified.json'` を参照
- `compose.yaml` で `./data:/data` をボリュームマウントしており、`data/` がローカルの永続的な設定・状態ディレクトリであることを裏付けている
- `.env.example` や `config.example.*` 等のテンプレートファイルは存在せず、README の手順に従って手動で設定ファイルを作成する必要がある
- `src/config.ts` で `data/config.json` から読み込む Config スキーマ（`discord.webhookUrl`/`token`/`channelId`）を定義している

これらは新規 worktree 作成時に引き継がれないと、Discord 通知の動作に必要な設定・状態が欠落するため、`.worktreeinclude` に追加します。

## 関連

https://github.com/book000/book000/issues/132
